### PR TITLE
Add Uniswap's multicall pattern

### DIFF
--- a/contracts/initializable/BondingCurve3.sol
+++ b/contracts/initializable/BondingCurve3.sol
@@ -9,8 +9,9 @@ import "../wallet/ShardedWallet.sol";
 import "../governance/IGovernance.sol";
 import "../interface/IERC1363Receiver.sol";
 import "../interface/IERC1363Spender.sol";
+import "../utils/Multicall.sol";
 
-contract LiquidityToken is ERC20 {
+contract LiquidityToken is ERC20, Multicall {
     address public controler;
 
     modifier onlyControler() {
@@ -41,7 +42,7 @@ contract LiquidityToken is ERC20 {
     }
 }
 
-contract BondingCurve3 is IERC1363Spender {
+contract BondingCurve3 is IERC1363Spender, Multicall {
     struct CurveCoordinates {
         uint256 x;
         uint256 k;

--- a/contracts/modules/ModuleBase.sol
+++ b/contracts/modules/ModuleBase.sol
@@ -2,10 +2,11 @@
 
 pragma solidity ^0.8.0;
 
+import "../utils/Multicall.sol";
 import "../wallet/ShardedWallet.sol";
 import "./IModule.sol";
 
-abstract contract ModuleBase is IModule
+abstract contract ModuleBase is IModule, Multicall
 {
     address immutable public walletTemplate;
 

--- a/contracts/utils/Multicall.sol
+++ b/contracts/utils/Multicall.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >0.8.0;
+
+/// @title Multicall
+/// @author Uniswap (https://github.com/Uniswap/uniswap-v3-periphery/blob/main/contracts/base/Multicall.sol)
+/// @notice Enables calling multiple methods in a single call to the contract
+abstract contract Multicall {
+    function multicall(bytes[] calldata data) external returns (bytes[] memory results) {
+        results = new bytes[](data.length);
+        for (uint256 i = 0; i < data.length; ++i) {
+            (bool success, bytes memory result) = address(this).delegatecall(data[i]);
+
+            if (!success) {
+                // Next 5 lines from https://ethereum.stackexchange.com/a/83577
+                if (result.length < 68) revert();
+                assembly {
+                    result := add(result, 0x04)
+                }
+                revert(abi.decode(result, (string)));
+            }
+
+            results[i] = result;
+        }
+    }
+}

--- a/contracts/wallet/ShardedWallet.sol
+++ b/contracts/wallet/ShardedWallet.sol
@@ -8,8 +8,9 @@ import "../governance/IGovernance.sol";
 import "../initializable/Ownable.sol";
 import "../initializable/ERC20.sol";
 import "../initializable/ERC1363.sol";
+import "../utils/Multicall.sol";
 
-contract ShardedWallet is Ownable, ERC20, ERC1363Approve
+contract ShardedWallet is Ownable, ERC20, ERC1363Approve, Multicall
 {
     // bytes32 public constant ALLOW_GOVERNANCE_UPGRADE = bytes32(uint256(keccak256("ALLOW_GOVERNANCE_UPGRADE")) - 1);
     bytes32 public constant ALLOW_GOVERNANCE_UPGRADE = 0xedde61aea0459bc05d70dd3441790ccfb6c17980a380201b00eca6f9ef50452a;


### PR DESCRIPTION
This is usefull to batch calls to a contract.

Example: I want to do 5 transfers on a ShardedWallet instance
- I encode these 5 transfers (giving me 5 bytes)
- I call `instance.multicall([ ...transfersCalls ])`
- that's it !

Uniswap's code has been modifier to not support payable. I would have been dangerous to support multicalls with value, as the value would have been considered multiple times:/